### PR TITLE
3B+向けのURL追加

### DIFF
--- a/10.md
+++ b/10.md
@@ -19,6 +19,7 @@
 * 次回のROSからLinuxをUbuntu 16.04にします
 * 次の「イメージ」をmicroSDにddのこと
   * http://file.ueda.tech/RPIM_BOOK/ubuntu-16.04-raspimouse-ros-book-part1+catkin_ws.img.xz
+  * Raspberry Pi 3B+ を使用している方は[上田研の齋藤敦さんのブログ](https://www.asrobot.me/entry/2018/07/11/001603/)の「アップグレード＆ROS Kinetic＆カーネルコンパイル済み」を利用
   * 初期パスワード, ID共にubuntu
   * ROSインストール済み
 

--- a/12.md
+++ b/12.md
@@ -88,7 +88,7 @@
       * 中にあるシェルスクリプトをstep0.bash, step1.bash, locale.ja.bashと実行すればOK
 * 講義ではインストール済みのイメージファイルを利用
   * 参考: [昨年の講義資料](https://lab.ueda.tech/?presenpress=%E3%83%AD%E3%83%9C%E3%83%83%E3%83%88%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0%E5%AD%A62016%E7%AC%AC12%E5%9B%9E#/15)
-
+  * Raspberry Pi 3B+ を使用している方は[上田研の齋藤敦さんのブログ](https://www.asrobot.me/entry/2018/07/11/001603/)の「アップグレード＆ROS Kinetic＆カーネルコンパイル済み」を利用
 ## 動作確認
 
 * `roscore`


### PR DESCRIPTION
Raspberry Pi 3B+でROSを動かすためのイメージファイルのURL（齋藤さんのブロク）を追加。（本人からの掲載許可あり）